### PR TITLE
Add StatementId to Result

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -493,9 +493,10 @@ type Message struct {
 
 // Result represents a resultset returned from a single statement.
 type Result struct {
-	Series   []models.Row
-	Messages []*Message
-	Err      string `json:"error,omitempty"`
+	StatementId int `json:"statement_id"`
+	Series      []models.Row
+	Messages    []*Message
+	Err         string `json:"error,omitempty"`
 }
 
 // Query sends a command to the server and returns the Response.


### PR DESCRIPTION
The current version of this library won't allow inspection of the `statement_id` for a given result. This means that, for a chunked response to a multiple statement query, we're unable to understand to which statement does the result correspond, since we don't have a single response with all the results in a single array.