### PR TITLE
fix precision verification

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -244,7 +244,11 @@ func NewBatchPoints(conf BatchPointsConfig) (BatchPoints, error) {
 	if conf.Precision == "" {
 		conf.Precision = "ns"
 	}
-	if _, err := time.ParseDuration("1" + conf.Precision); err != nil {
+	switch conf.Precision {
+	case "", "n", "ns", "u", "ms", "s", "m", "h":
+		// it's valid
+	default:
+		err := fmt.Errorf("invalid precision %q (use n, u, ms, s, m or h)", conf.Precision)
 		return nil, err
 	}
 	bp := &batchpoints{
@@ -293,7 +297,14 @@ func (bp *batchpoints) RetentionPolicy() string {
 }
 
 func (bp *batchpoints) SetPrecision(p string) error {
-	if _, err := time.ParseDuration("1" + p); err != nil {
+	if p == "" {
+		p = "ns"
+	}
+	switch p {
+	case "", "n", "ns", "u", "ms", "s", "m", "h":
+		// it's valid
+	default:
+		err := fmt.Errorf("invalid precision %q (use n, u, ms, s, m or h)", p)
 		return err
 	}
 	bp.precision = p

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -802,15 +802,37 @@ func TestClient_PointFields(t *testing.T) {
 }
 
 func TestBatchPoints_PrecisionError(t *testing.T) {
-	_, err := NewBatchPoints(BatchPointsConfig{Precision: "foobar"})
-	if err == nil {
-		t.Errorf("Precision: foobar should have errored")
+	tests := []struct {
+		precision     string
+		wantPrecision string
+		wantErr       bool
+	}{
+		{precision: "", wantPrecision: "ns", wantErr: false},
+		{precision: "ns", wantPrecision: "ns", wantErr: false},
+		{precision: "u", wantPrecision: "u", wantErr: false},
+		{precision: "ms", wantPrecision: "ms", wantErr: false},
+		{precision: "s", wantPrecision: "s", wantErr: false},
+		{precision: "m", wantPrecision: "m", wantErr: false},
+		{precision: "h", wantPrecision: "h", wantErr: false},
+		{precision: "foobar", wantPrecision: "ns", wantErr: true},
+		{precision: "us", wantPrecision: "ns", wantErr: true},
 	}
 
-	bp, _ := NewBatchPoints(BatchPointsConfig{Precision: "ns"})
-	err = bp.SetPrecision("foobar")
-	if err == nil {
-		t.Errorf("Precision: foobar should have errored")
+	for _, test := range tests {
+		_, err := NewBatchPoints(BatchPointsConfig{Precision: test.precision})
+		if (err != nil) != test.wantErr {
+			t.Errorf("Precision \"%s\": error = %v, wantErr %v", test.precision, err, test.wantErr)
+		}
+
+		bp, _ := NewBatchPoints(BatchPointsConfig{Precision: "ns"})
+		err = bp.SetPrecision(test.precision)
+		if (err != nil) != test.wantErr {
+			t.Errorf("SetPrecision(\"%s\"): error = %v, wantErr %v", test.precision, err, test.wantErr)
+		}
+
+		if got := bp.Precision(); got != test.wantPrecision {
+			t.Errorf("Precision() returned \"%s\", want \"%s\"", got, test.wantPrecision)
+		}
 	}
 }
 


### PR DESCRIPTION
* use same verification introduced to InfluxDB server at version 1.8.0
* SetPrecision() now replaces "" by default "ns"
* fixes #38