### PR TITLE
feat: add support for complex bound parameters

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -465,6 +465,9 @@ type Query struct {
 	Parameters      map[string]interface{}
 }
 
+// Params is a type alias to the query parameters.
+type Params map[string]interface{}
+
 // NewQuery returns a query object.
 // The database and precision arguments can be empty strings if they are not needed for the query.
 func NewQuery(command, database, precision string) Query {

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -263,3 +263,23 @@ func ExampleClient_createDatabase() {
 		fmt.Println(response.Results)
 	}
 }
+
+func ExampleClient_queryWithParams() {
+	// Make client
+	c, err := client.NewHTTPClient(client.HTTPConfig{
+		Addr: "http://localhost:8086",
+	})
+	if err != nil {
+		fmt.Println("Error creating InfluxDB Client: ", err.Error())
+	}
+	defer c.Close()
+
+	q := client.NewQueryWithParameters("SELECT $fn($value) FROM $m", "square_holes", "ns", client.Params{
+		"fn":    client.Identifier("count"),
+		"value": client.Identifier("value"),
+		"m":     client.Identifier("shapes"),
+	})
+	if response, err := c.Query(q); err == nil && response.Error() == nil {
+		fmt.Println(response.Results)
+	}
+}

--- a/v2/params.go
+++ b/v2/params.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type (
+	// Identifier is an identifier value.
+	Identifier string
+
+	// StringValue is a string literal.
+	StringValue string
+
+	// RegexValue is a regexp literal.
+	RegexValue string
+
+	// NumberValue is a number literal.
+	NumberValue float64
+
+	// IntegerValue is an integer literal.
+	IntegerValue int64
+
+	// BooleanValue is a boolean literal.
+	BooleanValue bool
+
+	// TimeValue is a time literal.
+	TimeValue time.Time
+
+	// DurationValue is a duration literal.
+	DurationValue time.Duration
+)
+
+func (v Identifier) MarshalJSON() ([]byte, error) {
+	m := map[string]string{"identifier": string(v)}
+	return json.Marshal(m)
+}
+
+func (v StringValue) MarshalJSON() ([]byte, error) {
+	m := map[string]string{"string": string(v)}
+	return json.Marshal(m)
+}
+
+func (v RegexValue) MarshalJSON() ([]byte, error) {
+	m := map[string]string{"regex": string(v)}
+	return json.Marshal(m)
+}
+
+func (v NumberValue) MarshalJSON() ([]byte, error) {
+	m := map[string]float64{"number": float64(v)}
+	return json.Marshal(m)
+}
+
+func (v IntegerValue) MarshalJSON() ([]byte, error) {
+	m := map[string]int64{"integer": int64(v)}
+	return json.Marshal(m)
+}
+
+func (v BooleanValue) MarshalJSON() ([]byte, error) {
+	m := map[string]bool{"boolean": bool(v)}
+	return json.Marshal(m)
+}
+
+func (v TimeValue) MarshalJSON() ([]byte, error) {
+	t := time.Time(v)
+	m := map[string]string{"string": t.Format(time.RFC3339Nano)}
+	return json.Marshal(m)
+}
+
+func (v DurationValue) MarshalJSON() ([]byte, error) {
+	m := map[string]int64{"duration": int64(v)}
+	return json.Marshal(m)
+}


### PR DESCRIPTION
This updates influxql to a newer version that supports complex bound
parameters. This allows bound parameters to be used as identifiers,
regexes, and durations along with the already existing strings, numbers,
and booleans.

This updates the influxdb client to support passing bound parameters as
part of the parameters json and updates the readme to show how to use
this feature.

influxdata/influxdb@8d3496f0a3061375b454fae745d6ddf478bf8356