### PR TITLE
fix: enable large queries via POST body encoding

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -671,12 +671,15 @@ func (c *client) createDefaultRequest(q Query) (*http.Request, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", u.String(), nil)
+	body := url.Values{}
+	body.Set("q", q.Command)
+
+	req, err := http.NewRequest("POST", u.String(), strings.NewReader(body.Encode()))
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Set("Content-Type", "")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", c.useragent)
 
 	if c.username != "" {
@@ -684,7 +687,6 @@ func (c *client) createDefaultRequest(q Query) (*http.Request, error) {
 	}
 
 	params := req.URL.Query()
-	params.Set("q", q.Command)
 	params.Set("db", q.Database)
 	if q.RetentionPolicy != "" {
 		params.Set("rp", q.RetentionPolicy)


### PR DESCRIPTION
1. Add essentially this patch https://github.com/influxdata/influxdb/pull/22690
1. Which was self addressing https://github.com/influxdata/influxdb/issues/22694

I know this project is essentially dead and on fossilized maintenance but I'm not able to migrate off it; thus I need this patch to fix some scaling issues I've encountered.